### PR TITLE
docs(revolutPay): add action, radius and variant types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -351,8 +351,10 @@ export type FieldStyles = Partial<StatusRecord<Partial<CSSStyleDeclaration>>>
 export type FieldClasses = Partial<StatusRecord<string>>
 
 export type ButtonStyleOptions = {
-  variant?: 'dark' | 'light' | 'auto'
   size?: 'large' | 'small'
+  radius?: 'none' | 'small' | 'large'
+  variant?: 'dark' | 'light' | 'light-outlined'
+  action?: 'donate' | 'pay' | 'subscribe' | 'buy'
 }
 
 export interface Address {


### PR DESCRIPTION
## Revolut Pay Typings 
This PR updates the types for Revolut Pay's `buttonStyles`. 

## Usage 

```js 
RC.revolutPay({
  buttonStyle: {
    // options go here
    size: 'small' | 'large',
    radius: 'none' | 'small' | 'large',
    variant: 'light' | 'dark' | 'light-outlined' ,
    action: 'donate' | 'pay' | 'subscribe' | 'buy',
  }
})
```