### PR TITLE
docs(card-field): add the savePaymentMethodFor submit option

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -463,7 +463,9 @@ export interface PaymentRequestOptions extends CommonOptions {
 
 export interface RevolutCheckoutCardField extends RevolutCheckoutInstance {
   /** Submit entered card details along with a customer details */
-  submit: (meta?: CustomerDetails) => void
+  submit: (
+    meta?: CustomerDetails & CommonOptions['savePaymentMethodFor']
+  ) => void
   /** Manually trigger validation, by default field will show errors only after user interacted with it */
   validate: () => void
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -357,6 +357,9 @@ export type ButtonStyleOptions = {
   action?: 'donate' | 'pay' | 'subscribe' | 'buy'
 }
 
+export type SubmitMeta = CustomerDetails &
+  Pick<CommonOptions, 'savePaymentMethodFor'>
+
 export interface Address {
   countryCode: CountryCode
   postcode: string
@@ -463,9 +466,7 @@ export interface PaymentRequestOptions extends CommonOptions {
 
 export interface RevolutCheckoutCardField extends RevolutCheckoutInstance {
   /** Submit entered card details along with a customer details */
-  submit: (
-    meta?: CustomerDetails & CommonOptions['savePaymentMethodFor']
-  ) => void
+  submit: (meta?: SubmitMeta) => void
   /** Manually trigger validation, by default field will show errors only after user interacted with it */
   validate: () => void
 }


### PR DESCRIPTION
The `submit` handler for the card field widget was missing the `savePaymentMethodFor` option as described in the docs: 
![CleanShot 2021-10-29 at 13 18 17@2x](https://user-images.githubusercontent.com/10930234/139433002-0ad16666-2d78-4d7f-9a6b-928db2e82b66.png)

