### PR TITLE
📝 docs: add height to button style options

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -351,6 +351,7 @@ export type FieldStyles = Partial<StatusRecord<Partial<CSSStyleDeclaration>>>
 export type FieldClasses = Partial<StatusRecord<string>>
 
 export type ButtonStyleOptions = {
+  height?: string
   size?: 'large' | 'small'
   radius?: 'none' | 'small' | 'large'
   variant?: 'dark' | 'light' | 'light-outlined'


### PR DESCRIPTION
As described in the PR title. Relevant for payment request buttons and revolut pay buttons