### PR TITLE
fix: export Mode in root `index`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,5 @@ export {
   Locale,
   RevolutCheckoutCardField,
   RevolutCheckoutInstance,
+  Mode
 } from './types'


### PR DESCRIPTION
Currently the only way to import Mode is specifying:

`import { Mode } from '@revolut/checkout/types/types'`

With this change, the import will look like:

`import {Mode} from '@revolut/checkout'`