### PR TITLE
fix(types): missing validation type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -267,6 +267,7 @@ export type ValidationErrorType =
   | 'validation.card.cvv.required'
   | 'validation.card.type.invalid'
   | 'validation.postcode.invalid'
+  | 'validation.postcode.country-invalid'
   | 'validation.postcode.required'
   | 'validation.email.incomplete'
   | 'validation.email.invalid'


### PR DESCRIPTION
The following type is possible to be returned to the FE and it's currently not mapped into the validation types.