### PR TITLE
✨ feat: add payments module loader

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { RevolutCheckoutLoader as default } from './loader'
+export { RevolutPaymentsLoader } from './paymentsLoader'
 export {
   isRevolutCheckoutError,
   isValidationError,
@@ -15,5 +16,5 @@ export {
   Locale,
   RevolutCheckoutCardField,
   RevolutCheckoutInstance,
-  Mode
+  Mode,
 } from './types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 export { RevolutCheckoutLoader as default } from './loader'
-export { RevolutPaymentsLoader } from './paymentsLoader'
 export {
   isRevolutCheckoutError,
   isValidationError,

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,5 +1,6 @@
 import { MODE, URLS } from './constants'
-import { RevolutCheckout, RevolutCheckoutInstance, Mode } from './types'
+import { RevolutPaymentsLoader } from './paymentsLoader'
+import { RevolutCheckout, RevolutCheckoutInstance, Mode, Locale } from './types'
 
 let loaded: RevolutCheckout = null
 
@@ -59,3 +60,14 @@ export function RevolutCheckoutLoader(
 }
 
 RevolutCheckoutLoader.mode = MODE.PRODUCTION
+
+type PaymentModuleParams = {
+  locale: Locale
+  mode: Mode
+  publicToken: string
+}
+RevolutCheckoutLoader.payments = ({
+  locale,
+  publicToken,
+  mode = RevolutCheckoutLoader.mode,
+}: PaymentModuleParams) => RevolutPaymentsLoader(publicToken, mode, locale)

--- a/src/payments.test.js
+++ b/src/payments.test.js
@@ -4,7 +4,7 @@ import { fireEvent } from '@testing-library/dom'
 afterEach(() => jest.resetModules())
 
 function setup() {
-  const RevolutPayments = require('./index').RevolutPaymentsLoader
+  const RevolutCheckout = require('./index').default
   const script = document.createElement('script')
 
   const MockInstance = jest.fn()
@@ -31,13 +31,13 @@ function setup() {
 
   return {
     script,
-    RevolutPayments,
     MockInstance,
     MockPaymentInstance,
     MockRevolutPayments,
     MockRevolutCheckout,
     TriggerSuccess,
     TriggerError,
+    RevolutPayments: RevolutCheckout.payments,
   }
 }
 
@@ -51,7 +51,10 @@ test(`should load embed script for 'dev'`, async () => {
     TriggerSuccess,
   } = setup()
 
-  const promise = RevolutPayments('MERCHANT_PUBLIC_TOKEN_DEV_XXX', 'dev')
+  const promise = RevolutPayments({
+    mode: 'dev',
+    publicToken: 'MERCHANT_PUBLIC_TOKEN_DEV_XXX',
+  })
   const spyLoad = jest.spyOn(script, 'onload')
 
   expect(script).toHaveAttribute('id', 'revolut-payments')
@@ -82,7 +85,10 @@ test(`should load embed script for 'prod'`, async () => {
     TriggerSuccess,
   } = setup()
 
-  const promise = RevolutPayments('MERCHANT_PUBLIC_TOKEN_PROD_XXX', 'prod')
+  const promise = RevolutPayments({
+    mode: 'prod',
+    publicToken: 'MERCHANT_PUBLIC_TOKEN_PROD_XXX',
+  })
   const spyLoad = jest.spyOn(script, 'onload')
 
   expect(script).toHaveAttribute('id', 'revolut-payments')
@@ -110,10 +116,10 @@ test(`should load embed script for 'sandbox'`, async () => {
     TriggerSuccess,
   } = setup()
 
-  const promise = RevolutPayments(
-    'MERCHANT_PUBLIC_TOKEN_SANDBOX_XXX',
-    'sandbox'
-  )
+  const promise = RevolutPayments({
+    mode: 'sandbox',
+    publicToken: 'MERCHANT_PUBLIC_TOKEN_SANDBOX_XXX',
+  })
   const spyLoad = jest.spyOn(script, 'onload')
 
   expect(script).toHaveAttribute('id', 'revolut-payments')
@@ -137,7 +143,7 @@ test(`should load embed script for 'sandbox'`, async () => {
 test('should not request new embed script and use loaded one', async () => {
   const { RevolutPayments, MockRevolutPayments, TriggerSuccess } = setup()
 
-  const promise = RevolutPayments('MERCHANT_PUBLIC_TOKEN_1')
+  const promise = RevolutPayments({ publicToken: 'MERCHANT_PUBLIC_TOKEN_1' })
 
   TriggerSuccess()
 
@@ -161,7 +167,9 @@ test(`should use 'prod' by default`, async () => {
     TriggerSuccess,
   } = setup()
 
-  const promise = RevolutPayments('MERCHANT_PUBLIC_TOKEN_PROD_XXX')
+  const promise = RevolutPayments({
+    publicToken: 'MERCHANT_PUBLIC_TOKEN_PROD_XXX',
+  })
   const spyLoad = jest.spyOn(script, 'onload')
 
   expect(script).toHaveAttribute('id', 'revolut-payments')
@@ -184,7 +192,9 @@ test.only('should throw error on failed loading', async () => {
   const { RevolutPayments, TriggerError } = setup()
 
   try {
-    const promise = RevolutPayments('MERCHANT_PUBLIC_TOKEN_PROD_XXX')
+    const promise = RevolutPayments({
+      publicToken: 'MERCHANT_PUBLIC_TOKEN_PROD_XXX',
+    })
 
     TriggerError()
 

--- a/src/payments.test.js
+++ b/src/payments.test.js
@@ -1,0 +1,195 @@
+import '@testing-library/jest-dom'
+import { fireEvent } from '@testing-library/dom'
+
+afterEach(() => jest.resetModules())
+
+function setup() {
+  const RevolutPayments = require('./index').RevolutPaymentsLoader
+  const script = document.createElement('script')
+
+  const MockInstance = jest.fn()
+  const MockRevolutCheckout = jest.fn(() => MockInstance)
+
+  const MockPaymentInstance = jest.fn()
+  const MockRevolutPayments = jest.fn(() => MockPaymentInstance)
+
+  const TriggerSuccess = jest.fn(() => {
+    setTimeout(() => {
+      window.RevolutCheckout = MockRevolutCheckout
+      window.RevolutCheckout.payments = MockRevolutPayments
+      fireEvent.load(script)
+    })
+  })
+
+  const TriggerError = jest.fn(() => {
+    setTimeout(() => {
+      fireEvent.error(script)
+    })
+  })
+
+  jest.spyOn(document, 'createElement').mockImplementationOnce(() => script)
+
+  return {
+    script,
+    RevolutPayments,
+    MockInstance,
+    MockPaymentInstance,
+    MockRevolutPayments,
+    MockRevolutCheckout,
+    TriggerSuccess,
+    TriggerError,
+  }
+}
+
+test(`should load embed script for 'dev'`, async () => {
+  const {
+    script,
+    RevolutPayments,
+    MockRevolutCheckout,
+    MockPaymentInstance,
+    MockRevolutPayments,
+    TriggerSuccess,
+  } = setup()
+
+  const promise = RevolutPayments('MERCHANT_PUBLIC_TOKEN_DEV_XXX', 'dev')
+  const spyLoad = jest.spyOn(script, 'onload')
+
+  expect(script).toHaveAttribute('id', 'revolut-payments')
+  expect(script).toHaveAttribute(
+    'src',
+    'https://merchant.revolut.codes/embed.js'
+  )
+
+  TriggerSuccess()
+
+  const instance = await promise
+
+  expect(spyLoad).toHaveBeenCalled()
+  expect(instance).toBe(MockPaymentInstance)
+  expect(MockRevolutCheckout).not.toHaveBeenCalled()
+  expect(MockRevolutPayments).toHaveBeenCalledWith({
+    publicToken: 'MERCHANT_PUBLIC_TOKEN_DEV_XXX',
+  })
+})
+
+test(`should load embed script for 'prod'`, async () => {
+  const {
+    script,
+    RevolutPayments,
+    MockPaymentInstance,
+    MockRevolutCheckout,
+    MockRevolutPayments,
+    TriggerSuccess,
+  } = setup()
+
+  const promise = RevolutPayments('MERCHANT_PUBLIC_TOKEN_PROD_XXX', 'prod')
+  const spyLoad = jest.spyOn(script, 'onload')
+
+  expect(script).toHaveAttribute('id', 'revolut-payments')
+  expect(script).toHaveAttribute('src', 'https://merchant.revolut.com/embed.js')
+
+  TriggerSuccess()
+
+  const instance = await promise
+
+  expect(spyLoad).toHaveBeenCalled()
+  expect(instance).toBe(MockPaymentInstance)
+  expect(MockRevolutCheckout).not.toHaveBeenCalled()
+  expect(MockRevolutPayments).toHaveBeenCalledWith({
+    publicToken: 'MERCHANT_PUBLIC_TOKEN_PROD_XXX',
+  })
+})
+
+test(`should load embed script for 'sandbox'`, async () => {
+  const {
+    script,
+    RevolutPayments,
+    MockRevolutCheckout,
+    MockPaymentInstance,
+    MockRevolutPayments,
+    TriggerSuccess,
+  } = setup()
+
+  const promise = RevolutPayments(
+    'MERCHANT_PUBLIC_TOKEN_SANDBOX_XXX',
+    'sandbox'
+  )
+  const spyLoad = jest.spyOn(script, 'onload')
+
+  expect(script).toHaveAttribute('id', 'revolut-payments')
+  expect(script).toHaveAttribute(
+    'src',
+    'https://sandbox-merchant.revolut.com/embed.js'
+  )
+
+  TriggerSuccess()
+
+  const instance = await promise
+
+  expect(spyLoad).toHaveBeenCalled()
+  expect(instance).toBe(MockPaymentInstance)
+  expect(MockRevolutCheckout).not.toHaveBeenCalled()
+  expect(MockRevolutPayments).toHaveBeenCalledWith({
+    publicToken: 'MERCHANT_PUBLIC_TOKEN_SANDBOX_XXX',
+  })
+})
+
+test('should not request new embed script and use loaded one', async () => {
+  const { RevolutPayments, MockRevolutPayments, TriggerSuccess } = setup()
+
+  const promise = RevolutPayments('MERCHANT_PUBLIC_TOKEN_1')
+
+  TriggerSuccess()
+
+  await promise
+  expect(MockRevolutPayments).toHaveBeenCalledWith({
+    publicToken: 'MERCHANT_PUBLIC_TOKEN_1',
+  })
+
+  await RevolutPayments('MERCHANT_PUBLIC_TOKEN_2')
+  expect(MockRevolutPayments).toHaveBeenCalledWith({
+    publicToken: 'MERCHANT_PUBLIC_TOKEN_2',
+  })
+})
+
+test(`should use 'prod' by default`, async () => {
+  const {
+    script,
+    RevolutPayments,
+    MockPaymentInstance,
+    MockRevolutPayments,
+    TriggerSuccess,
+  } = setup()
+
+  const promise = RevolutPayments('MERCHANT_PUBLIC_TOKEN_PROD_XXX')
+  const spyLoad = jest.spyOn(script, 'onload')
+
+  expect(script).toHaveAttribute('id', 'revolut-payments')
+  expect(script).toHaveAttribute('src', 'https://merchant.revolut.com/embed.js')
+
+  TriggerSuccess()
+
+  const instance = await promise
+
+  expect(spyLoad).toHaveBeenCalled()
+  expect(instance).toBe(MockPaymentInstance)
+  expect(MockRevolutPayments).toHaveBeenCalledWith({
+    publicToken: 'MERCHANT_PUBLIC_TOKEN_PROD_XXX',
+  })
+})
+
+test.only('should throw error on failed loading', async () => {
+  expect.assertions(1)
+
+  const { RevolutPayments, TriggerError } = setup()
+
+  try {
+    const promise = RevolutPayments('MERCHANT_PUBLIC_TOKEN_PROD_XXX')
+
+    TriggerError()
+
+    await promise
+  } catch (error) {
+    expect(error.message).toBe(`'RevolutPayments' failed to load`)
+  }
+})

--- a/src/paymentsLoader.ts
+++ b/src/paymentsLoader.ts
@@ -1,0 +1,52 @@
+import { MODE, URLS } from './constants'
+import {
+  Mode,
+  Locale,
+  RevolutCheckout,
+  RevolutPaymentsModuleInstance,
+} from './types'
+
+let loadedPaymentInstance: RevolutCheckout['payments'] = null
+
+export function RevolutPaymentsLoader(
+  token: string,
+  mode: Mode = RevolutPaymentsLoader.mode,
+  locale?: Locale
+): Promise<RevolutPaymentsModuleInstance> {
+  if (loadedPaymentInstance) {
+    const instance = loadedPaymentInstance({ publicToken: token, locale })
+    return Promise.resolve(instance)
+  }
+
+  const script = document.createElement('script')
+
+  script.id = 'revolut-payments'
+  script.src = URLS[mode]
+  script.async = true
+
+  document.head.appendChild(script)
+
+  return new Promise((resolve, reject) => {
+    function handleError() {
+      document.head.removeChild(script)
+
+      reject(new Error(`'RevolutPayments' failed to load`))
+    }
+
+    function handleLoad() {
+      if (typeof RevolutCheckout === 'function') {
+        resolve(RevolutCheckout.payments({ publicToken: token, locale }))
+
+        loadedPaymentInstance = RevolutCheckout.payments
+        delete window.RevolutCheckout
+      } else {
+        handleError()
+      }
+    }
+
+    script.onload = handleLoad
+    script.onerror = handleError
+  })
+}
+
+RevolutPaymentsLoader.mode = MODE.PRODUCTION

--- a/src/types.ts
+++ b/src/types.ts
@@ -475,21 +475,6 @@ export interface PaymentRequestInstance {
   destroy: () => void
 }
 
-export interface PaymentsModulePaymentRequestOptions
-  extends Omit<PaymentRequestOptions, 'token'> {
-  createOrder: () => Promise<{ publicId: string }>
-  amount: string
-  currency: string
-}
-
-export interface PaymentsModulePaymentRequestInstance {
-  mount: (
-    target: HTMLElement,
-    options: PaymentsModulePaymentRequestOptions
-  ) => PaymentRequestInstance
-  destroy: () => void
-}
-
 type CommonPaymentsRevolutPayOptions = {
   billingAddress?: Address
   buttonStyle?: ButtonStyleOptions
@@ -607,8 +592,6 @@ export interface RevolutCheckoutInstance {
 }
 
 export interface RevolutPaymentsModuleInstance {
-  /** Accept payments via the W3C payment request API */
-  paymentRequest: PaymentsModulePaymentRequestInstance
   /** Accept payments via Revolut pay v2 */
   revolutPay: PaymentsModuleRevolutPayInstance
   /** Manually destroy the instance	 */


### PR DESCRIPTION
## Problem 
Right now. the `RevolutCheckout` loader can only be initialised with a public order ID. 

The problem here is that every instantiation of the loader requires that an order ID be created in advance. 

![CleanShot 2022-06-21 at 12 22 42](https://user-images.githubusercontent.com/10930234/174777651-e8dfcbb5-142d-4954-ad1c-b6fe52af26be.png)

In large merchant sites, this results in so **numerous dropped off orders created**. 

## Solution 
Internally, the widget has been redesigned to be initiated with a public merchant token. 

![CleanShot 2022-06-21 at 12 27 25](https://user-images.githubusercontent.com/10930234/174778653-298563ae-4953-417d-88af-a9d4ce187078.png)


This token does not change (except regenerated) and is safe to be kept (or stored) on the client. 

NB: **This initialisation does not rely on a order been created** 

### Backwards compatility 
For backwards compatibility, the newer API has been wrapped up in a separate `payments` module. 

It is still possible to use the `RevolutCheckout` as it is i.e., with an order ID: 

```js
  import RevolutCheckoutLoader from '@revolut/checkout'
  
  // initialise the checkout widgets ... 
  RevolutCheckout('order_id', 'prod') 
```

However, to reap the benefits of the newer implementation, a merchant developer would do the following: 

```js
  import { RevolutPaymentsLoader } from '@revolut/checkout'

 // initialise with a merchant public token
  RevolutPaymentsLoader('merchant-public-token', 'prod') 

```

## Note 
At this time, NOT all  widget methods are available in the new `payments` instance. This requires an internal rewrite.

Right now, here's the state of the other payment methods: 

- [x] `revolutPay` (version 2)
- [ ] `paymentRequest` (Apple pay / Google pay) - to be updated shortly 
- [ ] `cardField` (not avaialble) 
- [ ] `payWithPopup` (not available)



## Edit: updated API 
The payment loader is now kept internal and the single default export loader used.

```js
import RevolutCheckout from '@revolut/checkout'

// older API 
RevolutCheckout("ORDER_ID", "dev")

// payments module 
RevolutCheckout.payments({
    publicToken: 'PUBLIC_TOKEN',
    mode: 'dev'
 })
```

