### PR TITLE
 docs: update revolut pay v2 types

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -63,8 +63,8 @@ RevolutCheckoutLoader.mode = MODE.PRODUCTION
 
 type PaymentModuleParams = {
   locale: Locale
-  mode: Mode
   publicToken: string
+  mode?: Mode
 }
 RevolutCheckoutLoader.payments = ({
   locale,

--- a/src/types.ts
+++ b/src/types.ts
@@ -479,7 +479,7 @@ type CommonPaymentsRevolutPayOptions = {
   billingAddress?: Address
   buttonStyle?: ButtonStyleOptions
   validate?: () => Promise<boolean> | boolean
-  createOrder: () => { publicId: string } | Promise<{ publicId: string }>
+  createOrder: () => Promise<{ publicId: string }>
 }
 
 type RevolutPayLineItem = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -479,7 +479,7 @@ type CommonPaymentsRevolutPayOptions = {
   billingAddress?: Address
   buttonStyle?: ButtonStyleOptions
   validate?: () => Promise<boolean> | boolean
-  createOrder: () => Promise<{ publicId: string }>
+  createOrder: () => { publicId: string } | Promise<{ publicId: string }>
 }
 
 type RevolutPayLineItem = {
@@ -546,7 +546,7 @@ type RevolutPayEvents = {
     | {
         type: 'success'
       }
-    | { type: 'error'; error: Error }
+    | { type: 'error'; error: RevolutCheckoutError }
     | { type: 'cancel'; dropOffState: RevolutPayDropOffState }
 }
 


### PR DESCRIPTION
Minor updates to the exposed revolut pay v2 types. 

- `mode` should be optional. Similar to  the default `RevolutCheckout` loader
- The `error` type should be the more explicit `RevolutCheckoutError` 