### PR TITLE
fix: update types for error messages

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -288,6 +288,8 @@ export type RevolutCheckoutErrorType =
   | 'error.deactivated-merchant'
   | 'error.invalid-postcode'
   | 'error.invalid-email'
+  | 'error.invalid-name'
+  | 'error.invalid-address'
   | 'error.do-not-honour'
   | 'error.insufficient-funds'
   | 'error.3ds-failed'


### PR DESCRIPTION

## What? 
Adds new error types to `RevolutCheckoutErrorType`  namely: 

 - `error.invalid-name`
 - `error.invalid-address`