### PR TITLE
✨ feat: expose revpay URL helpers

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,7 +9,7 @@ export const LOCALES = [
   'pt',
   'es',
   'cs',
-  'hu'
+  'hu',
 ] as const
 
 export const MODE = {
@@ -27,3 +27,7 @@ export const URLS = {
 } as const
 
 export type URLS = typeof URLS
+
+export const REVOLUT_PAY_ORDER_ID_URL_PARAMETER = '_rp_oid'
+export const REVOLUT_PAY_SUCCESS_REDIRECT_URL_PARAMETER = '_rp_s'
+export const REVOLUT_PAY_FAILURE_REDIRECT_URL_PARAMETER = '_rp_fr'

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,17 @@
+import {
+  REVOLUT_PAY_ORDER_ID_URL_PARAMETER,
+  REVOLUT_PAY_SUCCESS_REDIRECT_URL_PARAMETER,
+  REVOLUT_PAY_FAILURE_REDIRECT_URL_PARAMETER,
+} from './constants'
+
+const getSearchParamsByName = (name: string) =>
+  new URLSearchParams(window.location.search).get(name)
+
+export const getRevolutPayOrderIdURLParam = () =>
+  getSearchParamsByName(REVOLUT_PAY_ORDER_ID_URL_PARAMETER)
+
+export const getRevolutPaySuccessURLParam = () =>
+  getSearchParamsByName(REVOLUT_PAY_SUCCESS_REDIRECT_URL_PARAMETER)
+
+export const getRevolutPayFailureURLParam = () =>
+  getSearchParamsByName(REVOLUT_PAY_FAILURE_REDIRECT_URL_PARAMETER)

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -7,11 +7,20 @@ import {
 const getSearchParamsByName = (name: string) =>
   new URLSearchParams(window.location.search).get(name)
 
+/**
+ * Retrieve the revolut pay order ID URL parameter upon redirect to your merchant site
+ */
 export const getRevolutPayOrderIdURLParam = () =>
   getSearchParamsByName(REVOLUT_PAY_ORDER_ID_URL_PARAMETER)
 
+/**
+ * Retrieve the revolut pay success URL parameter upon redirect to your merchant site
+ */
 export const getRevolutPaySuccessURLParam = () =>
   getSearchParamsByName(REVOLUT_PAY_SUCCESS_REDIRECT_URL_PARAMETER)
 
+/**
+ * Retrieve the revolut pay failure URL parameter upon redirect to your merchant site
+ */
 export const getRevolutPayFailureURLParam = () =>
   getSearchParamsByName(REVOLUT_PAY_FAILURE_REDIRECT_URL_PARAMETER)

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,3 +17,9 @@ export {
   RevolutCheckoutInstance,
   Mode,
 } from './types'
+
+export {
+  getRevolutPayOrderIdURLParam,
+  getRevolutPaySuccessURLParam,
+  getRevolutPayFailureURLParam,
+} from './helpers'


### PR DESCRIPTION
## What? 
- This PR exposes basic revolut pay helpers. 
- These are convenience methods e.g., to grab a revolut pay order ID from the redirected url on mobile (app not installed flow) 


### NB: 
These helpers rely on [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) which isn't supported in IE and  Opera mini. See [caniuse](https://caniuse.com/?search=URLSearchParams)