### PR TITLE
doc: add poll payment state API

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -611,6 +611,16 @@ export interface RevolutPaymentsModuleInstance {
   destroy: () => void
   /** Controls the language of the text in the widget */
   setDefaultLocale: (lang: Locale) => void
+  /** Poll and react to the status of an order payment */
+  pollPaymentState: (
+    orderToken: string,
+    callbacks: {
+      onSuccess: () => void
+      onError: (error: RevolutCheckoutError) => void
+      /** Specifically handle poll errors e.g., network connection issues. Return a value (nullable) to stop polling completely */
+      onPollError?: (error: Error) => void
+    }
+  ) => () => void
 }
 
 export interface RevolutPaymentsModuleOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -618,7 +618,7 @@ export interface RevolutPaymentsModuleInstance {
       onSuccess: () => void
       onError: (error: RevolutCheckoutError) => void
       /** Specifically handle poll errors e.g., network connection issues. Return a value (nullable) to stop polling completely */
-      onPollError?: (error: Error) => void
+      onPollError?: (error: RevolutCheckoutError) => void
     }
   ) => () => void
 }


### PR DESCRIPTION
## What? 
Exposes the `pollPaymentState` API in the payments module. 

## NB 
This will likely be a rarely used API. However, in certain novel custom integrations, there might be a need to react specifically to the poll order payment state. 